### PR TITLE
Revert "Bump liquidpy from 0.6.3 to 0.7.0"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 PyGithub==1.55
 pyyaml==5.4
-liquidpy==0.7.0
+liquidpy==0.6.3


### PR DESCRIPTION
This version breaks something

Reverts Katsute/Katsute#12